### PR TITLE
fix postgres healthcheck

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     volumes:
       - db-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "pg_isready"]
+      test: ["CMD", "pg_isready", "-U", "graph-node"]
       interval: 30s
       timeout: 10s
       retries: 15


### PR DESCRIPTION
Postgres health check wasn't working throwing `FATAL:  role "root" does not exist
` error in the log.

```
vscode ➜ /workspace (main) $ dev-logs-postgres
## Logs for substreams-starter-test1_devcontainer-postgres-1 (last 5 minutes, last 10 lines) ##


2025-01-07 06:23:24.278 UTC [1] LOG:  starting PostgreSQL 15.10 (Debian 15.10-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
2025-01-07 06:23:24.279 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2025-01-07 06:23:24.279 UTC [1] LOG:  listening on IPv6 address "::", port 5432
2025-01-07 06:23:24.285 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2025-01-07 06:23:24.333 UTC [28] LOG:  database system was shut down at 2025-01-07 06:23:22 UTC
2025-01-07 06:23:24.345 UTC [1] LOG:  database system is ready to accept connections
2025-01-07 06:23:54.110 UTC [38] FATAL:  role "root" does not exist
2025-01-07 06:24:24.703 UTC [46] FATAL:  role "root" does not exist
2025-01-07 06:24:54.966 UTC [52] FATAL:  role "root" does not exist
2025-01-07 06:25:25.197 UTC [59] FATAL:  role "root" does not exist
...
```

This PR fixes it by explicitly specifying the username.